### PR TITLE
Add turbopack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center">
+<p style="text-align:center;">
     <a href="https://webdriver.io/">
         <img alt="WebdriverIO loves Next.js" src="https://raw.githubusercontent.com/webdriverio-community/wdio-next-service/main/.github/assets/banner.png">
     </a>
@@ -96,6 +96,13 @@ Port to start the server on.
 
 Type: `number`<br />
 Default: `process.env.NUXT_PORT || config.devServer.port`
+
+### `turbopack`
+
+Whether to use the new [turbopack](https://nextjs.org/docs/app/api-reference/turbopack) incremental bundler. Requires NextJS 15 and above.
+
+Type: `boolean`<br />
+Default: `false`
 
 ----
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-next-service",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "description": "This service helps you to launch your application when using Next.js.",
   "author": "Christian Bromann <mail@bromann.dev>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-next-service",
-  "version": "0.1.3",
+  "version": "0.1.1",
   "description": "This service helps you to launch your application when using Next.js.",
   "author": "Christian Bromann <mail@bromann.dev>",
   "license": "MIT",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,6 @@ import url from 'node:url'
 import path from 'node:path'
 
 const dirname = url.fileURLToPath(new URL('.', import.meta.url))
-const packageJSONContent = (await fs.promises.readFile(path.resolve(dirname, '..', 'package.json'))).toString()
+const packageJSONContent = fs.readFileSync(path.resolve(dirname, '..', 'package.json')).toString()
 export const pkg = JSON.parse(packageJSONContent)
 export const PHASE = 'phase-development-server'

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -41,7 +41,9 @@ export class NuxtServiceLauncher {
             || await getPort()
         )
 
-        log.info(`Start Next.js dev server on ${this.#options.hostname}:${port}`)
+        const isTurbopack = this.#options.turbopack ?? false
+
+        log.info(`Start Next.js dev server on ${this.#options.hostname}:${port}${isTurbopack? ' with turbopack' : ''}`)
 
         /**
          * make sure to resolve Next module from the path where the next.config.mjs file is located
@@ -56,7 +58,8 @@ export class NuxtServiceLauncher {
                 env: {
                     ...process.env,
                     WDIO_NEXT_SERVICE: '1',
-                    NEXT_PRIVATE_WORKER: '1'
+                    NEXT_PRIVATE_WORKER: '1',
+                    ...(isTurbopack ? { TURBOPACK: '1' } : undefined),
                 }
             })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,4 +14,9 @@ export interface NextServiceOptions {
      * @default process.env.NUXT_PORT || config.devServer.port
      */
     port?: number
+    /**
+     * Whether to use the new turbopack  https://nextjs.org/docs/app/api-reference/turbopack incremental bundler
+     * @default false
+     */
+    turbopack?: boolean
 }


### PR DESCRIPTION
### Description

Thanks for this really useful service. We use turbopack in dev & we'd like to use it in our tests too. This PR allows us to enable it with configuration in the services block of the config file. 

   ```javascript
   services: [["next", { port: 3333, turbopack: true }]];
   ```

I also saw an error about top-level awaits during my testing of the PR, so I've factored out the async file read for a synchronous one to avoid it. 

