### PR TITLE
Expand peer dependency version to include NextJS 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "peerDependencies": {
     "@wdio/types": "^8.0.0 || ^9.0.0",
-    "next": "^14.2.4",
+    "next": "^14.0.0 || ^15.0.0",
     "webdriverio": "^8.0.0 || ^9.0.0"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       next:
-        specifier: ^14.2.4
+        specifier: ^14.0.0 || ^15.0.0
         version: 14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       webdriverio:
         specifier: ^8.0.0 || ^9.0.0


### PR DESCRIPTION
I've been using `v0.2.0` for the last month or so with Next JS 15 and all seems fine.

This resolves this warning during installation:
```
 WARN  Issues with peer dependencies found
.
├─┬ wdio-next-service 0.2.0
│ └── ✕ unmet peer next@^14.2.4: found 15.5.2
```