### PR TITLE
Add prefetch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Default: `localhost`
 Port to start the server on.
 
 Type: `number`<br />
-Default: `process.env.NUXT_PORT || config.devServer.port`
+Default: `process.env.NEXT_PORT || config.devServer.port`
 
 ### `turbopack`
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ export const config = {
     // ...
     services: [
         ['next', {
-            rootDir: './packages/next-app'
+            rootDir: './packages/next-app',
+            prefetch: ['/', '/about', '/contact']
         }]
     ],
     // ...
@@ -103,6 +104,13 @@ Whether to use the new [turbopack](https://nextjs.org/docs/app/api-reference/tur
 
 Type: `boolean`<br />
 Default: `false`
+
+### `prefetch`
+
+A list of paths to prefetch after server start. This can help to pre-warm the server and prevent the first test from timing out while it waits for compilation.
+
+Type: `string[]`<br />
+Default: `[]`
 
 ----
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export interface NextServiceOptions {
     hostname?: string
     /**
      * port to start the server on (random port picked if none provided)
-     * @default process.env.NUXT_PORT || config.devServer.port
+     * @default process.env.NEXT_PORT || config.devServer.port
      */
     port?: number
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,4 +19,9 @@ export interface NextServiceOptions {
      * @default false
      */
     turbopack?: boolean
+    /**
+     * A list of paths to prefetch after server start. This can help to pre-warm the server and prevent the first test from timing out while it waits for compilation.
+     * @default []
+     */
+    prefetch?: string[]
 }


### PR DESCRIPTION
Added a `prefetch` option enabling users to specify an array of paths to be fetched after server readiness but before tests commence.

This is useful when the compilation of the first route takes a long time to run in the CI environment and sometimes exceeds the timeout of the first test's wait